### PR TITLE
Fix nested template includes

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -208,7 +208,8 @@ function publicPing() {
 }
 
 function include(filename) {
-  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+  const template = HtmlService.createTemplateFromFile(filename);
+  return template.evaluate().getContent();
 }
 
 function renderStudentSubPage(payload) {


### PR DESCRIPTION
## Summary
- ensure the shared include() helper evaluates templates before returning their HTML
- allow nested include calls (dashboard -> page_* files) to render correctly in Apps Script

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3e6c4fd9c8328af05fa0f318c0522